### PR TITLE
Return JsonObject in PactDslJsonBody

### DIFF
--- a/pact-consumer/src/main/java/au/com/dius/pact/consumer/dsl/JSONObjectWrapper.kt
+++ b/pact-consumer/src/main/java/au/com/dius/pact/consumer/dsl/JSONObjectWrapper.kt
@@ -15,7 +15,7 @@ class JSONObjectWrapper {
         jsonObject.put(rootName, body)
     }
 
-    private val jsonObject = JSONObject()
+    val jsonObject = JSONObject()
 
     override fun toString(): String {
         return jsonObject.toString()

--- a/pact-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -89,7 +89,7 @@ public class PactDslJsonBody extends DslPart {
 
     @Override
     public Object getBody() {
-        return body;
+        return body.getJsonObject();
     }
 
     /**


### PR DESCRIPTION
Returning the `JsonObjectWrapper` in `getBody()` resulted in Problems when adding Objects to an Array. Returning the JsonObject from the Wrapper solves this Problem